### PR TITLE
Add support for broccoli environment variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-broccoli-build",
   "description": "Runs a Broccoli build via Grunt.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "homepage": "https://github.com/ericf/grunt-broccoli-build",
   "author": {
     "name": "Eric Ferraiuolo",
@@ -27,16 +27,16 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "^0.6.0",
-    "grunt-contrib-clean": "^0.4.0",
-    "grunt-contrib-nodeunit": "^0.2.0",
-    "grunt": "^0.4.3",
-    "broccoli": "^0.3.0",
-    "broccoli-static-compiler": "^0.1.1"
+    "grunt-contrib-jshint": "^0.9.2",
+    "grunt-contrib-clean": "^0.5.0",
+    "grunt-contrib-nodeunit": "^0.3.3",
+    "grunt": "^0.4.4",
+    "broccoli": "^0.4.1",
+    "broccoli-static-compiler": "^0.1.2"
   },
   "peerDependencies": {
     "grunt": ">= 0.4.1 < 0.5.0",
-    "broccoli": ">= 0.2.1"
+    "broccoli": ">= 0.4.0"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/broccoli_build.js
+++ b/tasks/broccoli_build.js
@@ -11,12 +11,15 @@
 module.exports = function (grunt) {
     grunt.registerMultiTask('broccoli_build', 'Runs a Broccoli build.', function () {
         var broccoli = require('broccoli'),
-            ncp      = require('ncp');
+            ncp      = require('ncp').ncp;
 
         var done = this.async(),
-            dest = this.data.dest;
+            dest = this.data.dest || 'build',
+            env  = this.data.env || 'development';
 
-        var tree    = broccoli.helpers.loadBrocfile(),
+        process.env['BROCCOLI_ENV'] = env;
+
+        var tree    = broccoli.loadBrocfile(),
             builder = new broccoli.Builder(tree);
 
         grunt.log.write('Broccoli building to "' + dest + '"...');


### PR DESCRIPTION
Also updates dependencies to newest versions, otherwise this breaks with newest version of broccoli because `broccoli.helpers.loadBrocfile()` is now `broccoli.loadBrocfile()`.

The environment variable is useful to have different builds for production and development, like it is the case in the [Broccoli Sample App](https://github.com/joliss/broccoli-sample-app).
