### PR TITLE
Add brocfile option to override default brocfile name

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "gruntplugin"
   ],
   "dependencies": {
+    "findup-sync": "^0.1.3",
     "ncp": "^0.5.0"
   }
 }


### PR DESCRIPTION
This adds the option to load a `Brocfile` with a specified name. Useful if you have multiple `Brocfile`s you want to build with a single `Gruntfile`.
